### PR TITLE
Add hero video component, add roadmap text

### DIFF
--- a/docs/.vitepress/theme/HeroVideo.vue
+++ b/docs/.vitepress/theme/HeroVideo.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="hero-video">
+    <iframe
+      src="https://www.youtube.com/embed/BEWxqYfrQek?si=B71YrLWsoTdD9dgM"
+      title="Montandon Overview"
+      frameborder="0"
+      allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
+      referrerpolicy="strict-origin-when-cross-origin"
+      allowfullscreen
+    />
+  </div>
+</template>
+
+<style scoped>
+.hero-video {
+  width: 100%;
+  max-width: 480px;
+}
+
+.hero-video iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 12px;
+  border: none;
+}
+
+@media (min-width: 960px) {
+  .hero-video {
+    padding-left: 32px;
+  }
+}
+</style>
+
+<style>
+@media (max-width: 959px) {
+  .VPHero .image {
+    order: 3;
+    margin-top: 24px;
+  }
+}
+
+.VPHero .image-bg {
+  pointer-events: none;
+}
+
+@media (min-width: 960px) {
+  .VPHero .image-container {
+    transform: none;
+  }
+
+  .VPHero .image {
+    position: relative;
+    z-index: 20;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,12 @@
+import DefaultTheme from 'vitepress/theme'
+import { h } from 'vue'
+import HeroVideo from './HeroVideo.vue'
+
+export default {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'home-hero-image': () => h(HeroVideo)
+    })
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,3 +25,7 @@ features:
   - title: STAC-compatible
     details: Montandon's data is organized in a SpatioTemporal Asset Catalog (STAC) format, making it easy to access and analyze geospatial data.
 ---
+
+## The road ahead
+
+Montandon is building toward a unified taxonomy for humanitarian crisis data — a shared semantic layer that lets any organization in the sector describe events, hazards, and impacts consistently. By correlating records from diverse sources through a common data model, Montandon lays the groundwork for true interoperability: from national societies to UN agencies, from research institutions to field operations, open by design.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,8 +24,6 @@ features:
     details: Montandon uses a unified taxonomy to categorize and standardize disaster data across different sources.
   - title: STAC-compatible
     details: Montandon's data is organized in a SpatioTemporal Asset Catalog (STAC) format, making it easy to access and analyze geospatial data.
+  - title: Common Data Model
+    details: Montandon's common data model allows for seamless integration and interoperability across different datasets and platforms.
 ---
-
-## The road ahead
-
-Montandon is building toward a unified taxonomy for humanitarian crisis data — a shared semantic layer that lets any organization in the sector describe events, hazards, and impacts consistently. By correlating records from diverse sources through a common data model, Montandon lays the groundwork for true interoperability: from national societies to UN agencies, from research institutions to field operations, open by design.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,6 +2,4 @@
 
 Montandon is the world’s largest disaster database.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/BEWxqYfrQek?si=B71YrLWsoTdD9dgM" title="YouTube video player" frameborder="0" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture;" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-
 ...


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Add Montandon Overview video to homepage (right of hero section)
- Remove video from `overview.md`
- Add feature card about unified data model

<img width="3248" height="2122" alt="CleanShot 2026-05-05 at 17 27 35@2x" src="https://github.com/user-attachments/assets/12760d12-298f-49c8-b7d1-27a897445670" />

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Help with Claude for the custom theme (VitePress only supports images where the video is, as far as I can tell).

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- `pnpm run docs:dev`